### PR TITLE
RIAWELC 데이터셋

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ Field Guide :
 
 ### Surface/Metal
 
-| Name                         | Modality | Task    | Annotation | Total | Normal | Defect | Year | License | Link       | Paper/Page |
-| ---------------------------- | -------- | ------- | ---------- | ----- | ------ | ------ | ---- | ------- | ---------- | ---------- |
-| (Example) NEU Surface Defect | RGB      | AD, Cls | Img        | -     | -      | -      | 2013 | -       | [Official] | [Paper]    |
-| (Please add)                 |          |         |            |       |        |        |      |         |            |            |
+| Name                         | Domain        | Modality            | Task    | Annotation | Total  | Normal | Defect     | Year | License         | Link                                          | Paper/Page                                                                                                                                                 |
+| ---------------------------- | ------------- | ------------------- | ------- | ---------- | ------ | ------ | ---------- | ---- | --------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| (Example) NEU Surface Defect | Metal surface | RGB                 | AD, Cls | Img        | -      | -      | -          | 2013 | -               | \[Official]                                   | \[Paper]                                                                                                                                                   |
+| RIAWELC                      | Weld (X-ray)  | Gray (Radiographic) | AD, Cls | Img-level  | 24,407 | ND     | LP, PO, CR   | 2022 | Freely released | [GitHub](https://github.com/stefyste/RIAWELC)                       | [1] [ICMECE 2022](https://www.researchgate.net/publication/369294451_RIAWELC_A_Novel_Dataset_of_Radiographic_Images_for_Automatic_Weld_Defects_Classification) <br> [2] [Manufacturing Letters (Elsevier)](https://doi.org/10.1016/j.mfglet.2022.100) |
 
 ## Related Repos/Resources
 


### PR DESCRIPTION
### Summary
- RIAWELC 용접 결함 데이터셋 정보 추가

### Details
1. RIAWELC 데이터셋에는 네 가지 용접 결함 클래스가 포함됨
   - LP (Lack of Penetration, 관통 불량)
   - PO (Porosity, 기공)
   - CR (Cracks, 균열)
   - ND (No Defect, 결함 없음)

2. 결함 유형을 고려했을 때 Body/Welding 파트에 해당하는 것으로 추측됨

3. 사용 시 인용해야 할 논문
   - Benito Totino, Fanny Spagnolo, Stefania Perri,  
     *RIAWELC: A Novel Dataset of Radiographic Images for Automatic Weld Defects Classification*,  
     ICMECE 2022  
   - Stefania Perri, Fanny Spagnolo, Fabio Frustaci, Pasquale Corsonello,  
     *Welding Defects Classification Through a Convolutional Neural Network*,  
     Manufacturing Letters, Elsevier