### PR TITLE
fix: 모바일 반응형(상단바 깨짐) 수정

### DIFF
--- a/standalone.html
+++ b/standalone.html
@@ -150,12 +150,12 @@ a:hover { text-decoration: underline; }
 .brand { min-width: 0; padding-right: 16px; }
 .brand h1 { margin: 0; font-size: 16px; letter-spacing: -.2px; font-weight: 700; line-height: 1.3; }
 .brand .sub { font-size: 11px; color: var(--text-dim); letter-spacing: .2px; }
-.top-actions { display: flex; align-items: center; gap: 8px; }
+.top-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
 
 .badge {
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
   color: #fff; font-weight: 700; padding: 6px 13px; border-radius: var(--radius-pill);
-  font-size: 12.5px; font-variant-numeric: tabular-nums;
+  font-size: 12.5px; font-variant-numeric: tabular-nums; white-space: nowrap;
   box-shadow: 0 4px 14px rgba(59,108,255,.35), inset 0 1px 0 rgba(255,255,255,.4);
 }
 
@@ -165,7 +165,7 @@ a:hover { text-decoration: underline; }
   -webkit-backdrop-filter: blur(8px) saturate(160%);
   backdrop-filter: blur(8px) saturate(160%);
   border: 1px solid var(--glass-brd);
-  padding: 7px 13px; border-radius: var(--radius-sm); font-size: 13px;
+  padding: 7px 13px; border-radius: var(--radius-sm); font-size: 13px; white-space: nowrap;
   box-shadow: inset 0 1px 0 var(--glass-rim), 0 2px 8px rgba(28,40,90,.08);
   transition: transform .12s ease, background .15s ease, box-shadow .15s ease;
 }
@@ -433,6 +433,26 @@ td.num { text-align: right; font-variant-numeric: tabular-nums; }
 @media (max-width: 920px) {
   .layout { grid-template-columns: 1fr; }
   .sidebar { position: static; max-height: none; }
+}
+@media (max-width: 768px) {
+  /* 상단바: 제목 위 / 버튼 줄 아래로 세로 배치 */
+  .topbar { flex-direction: column; align-items: stretch; gap: 10px; padding: 12px 16px; }
+  .brand { padding-right: 0; }
+  .brand h1 { font-size: 15px; }
+  .brand .sub { font-size: 10.5px; }
+  .top-actions { justify-content: flex-start; }
+  /* 본문 여백 축소 */
+  .layout { padding: 14px; gap: 14px; }
+  .stats { margin: 12px 14px 0; padding: 14px; }
+  .foot { margin: 4px 14px 22px; }
+  .toolbar-right { width: 100%; justify-content: space-between; }
+  /* 모달: 화면 꽉 차게 + 상세 1열 */
+  .modal { padding: 12px; }
+  .modal-panel { padding: 18px 16px; border-radius: 18px; }
+  .dl { grid-template-columns: 1fr; gap: 2px 0; }
+  .dl dt { padding-top: 10px; font-weight: 600; }
+  /* 폼: 1열 */
+  .form-grid { grid-template-columns: 1fr; }
 }
 
 /* ---------------- 접근성 ---------------- */
@@ -5144,7 +5164,7 @@ window.DATASETS = [
   "description": ""
  }
 ];
-window.DATASETS_META = { count: 82, source: "Datasets DB.csv" };
+window.DATASETS_META = { count: 82, source: "Datasets DB 275b7e86a5bd807d878fdb6f8c8fe382.csv" };
 
 </script>
   <script>

--- a/web/styles.css
+++ b/web/styles.css
@@ -142,12 +142,12 @@ a:hover { text-decoration: underline; }
 .brand { min-width: 0; padding-right: 16px; }
 .brand h1 { margin: 0; font-size: 16px; letter-spacing: -.2px; font-weight: 700; line-height: 1.3; }
 .brand .sub { font-size: 11px; color: var(--text-dim); letter-spacing: .2px; }
-.top-actions { display: flex; align-items: center; gap: 8px; }
+.top-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
 
 .badge {
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
   color: #fff; font-weight: 700; padding: 6px 13px; border-radius: var(--radius-pill);
-  font-size: 12.5px; font-variant-numeric: tabular-nums;
+  font-size: 12.5px; font-variant-numeric: tabular-nums; white-space: nowrap;
   box-shadow: 0 4px 14px rgba(59,108,255,.35), inset 0 1px 0 rgba(255,255,255,.4);
 }
 
@@ -157,7 +157,7 @@ a:hover { text-decoration: underline; }
   -webkit-backdrop-filter: blur(8px) saturate(160%);
   backdrop-filter: blur(8px) saturate(160%);
   border: 1px solid var(--glass-brd);
-  padding: 7px 13px; border-radius: var(--radius-sm); font-size: 13px;
+  padding: 7px 13px; border-radius: var(--radius-sm); font-size: 13px; white-space: nowrap;
   box-shadow: inset 0 1px 0 var(--glass-rim), 0 2px 8px rgba(28,40,90,.08);
   transition: transform .12s ease, background .15s ease, box-shadow .15s ease;
 }
@@ -425,6 +425,26 @@ td.num { text-align: right; font-variant-numeric: tabular-nums; }
 @media (max-width: 920px) {
   .layout { grid-template-columns: 1fr; }
   .sidebar { position: static; max-height: none; }
+}
+@media (max-width: 768px) {
+  /* 상단바: 제목 위 / 버튼 줄 아래로 세로 배치 */
+  .topbar { flex-direction: column; align-items: stretch; gap: 10px; padding: 12px 16px; }
+  .brand { padding-right: 0; }
+  .brand h1 { font-size: 15px; }
+  .brand .sub { font-size: 10.5px; }
+  .top-actions { justify-content: flex-start; }
+  /* 본문 여백 축소 */
+  .layout { padding: 14px; gap: 14px; }
+  .stats { margin: 12px 14px 0; padding: 14px; }
+  .foot { margin: 4px 14px 22px; }
+  .toolbar-right { width: 100%; justify-content: space-between; }
+  /* 모달: 화면 꽉 차게 + 상세 1열 */
+  .modal { padding: 12px; }
+  .modal-panel { padding: 18px 16px; border-radius: 18px; }
+  .dl { grid-template-columns: 1fr; gap: 2px 0; }
+  .dl dt { padding-top: 10px; font-weight: 600; }
+  /* 폼: 1열 */
+  .form-grid { grid-template-columns: 1fr; }
 }
 
 /* ---------------- 접근성 ---------------- */


### PR DESCRIPTION
모바일/좁은 화면에서 상단바 버튼이 글자 단위로 깨지는 이슈 수정. 별도 모바일 페이지 없이 반응형 CSS로 해결.

- 버튼·배지 `white-space: nowrap`
- `@media (max-width:768px)`: 상단바 세로 배치, 본문 여백 축소, 모달 상세/추가 폼 1열

390px·640px 뷰포트에서 정상 렌더 확인. styles.css 변경이라 머지 시 Pages 자동 재배포됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)