### PR TITLE
design: 2차 다듬기 (컬럼·용어·반응형·성능)

### DIFF
--- a/standalone.html
+++ b/standalone.html
@@ -87,6 +87,14 @@ a:hover { text-decoration: underline; }
 .hidden { display: none !important; }
 .svg-defs { position: absolute; width: 0; height: 0; pointer-events: none; }
 
+/* ---------------- 스크롤바 (테마에 맞춘 차분한 스타일) ---------------- */
+* { scrollbar-width: thin; scrollbar-color: color-mix(in srgb, var(--text-dim) 45%, transparent) transparent; }
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: color-mix(in srgb, var(--text-dim) 38%, transparent); border-radius: 8px; border: 2px solid transparent; background-clip: padding-box; }
+::-webkit-scrollbar-thumb:hover { background: color-mix(in srgb, var(--text-dim) 65%, transparent); }
+::-webkit-scrollbar-corner { background: transparent; }
+
 /* ---------------- 오로라 배경 ---------------- */
 .bg-aurora {
   position: fixed; inset: 0; z-index: -2; overflow: hidden;
@@ -126,12 +134,10 @@ a:hover { text-decoration: underline; }
   border: 1px solid var(--glass-brd);
   box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-rim), inset 0 0 0 1px rgba(255,255,255,.04);
 }
-/* Chromium 한정 굴절 향상 */
+/* Chromium 한정 굴절 향상 — 큰 스크롤 영역(표/카드)은 성능 위해 제외 */
 .refraction .topbar,
 .refraction .sidebar,
 .refraction .stats,
-.refraction .table-wrap,
-.refraction .card,
 .refraction .modal-panel {
   backdrop-filter: blur(var(--blur)) saturate(var(--sat)) url(#glass-refraction);
 }
@@ -310,7 +316,7 @@ a:hover { text-decoration: underline; }
   border: 1px solid var(--glass-brd);
   box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-rim);
 }
-table { border-collapse: collapse; width: 100%; font-size: 13px; }
+table { border-collapse: collapse; width: 100%; font-size: 13px; table-layout: fixed; min-width: 880px; }
 thead th {
   text-align: left; padding: 12px 14px; color: var(--text-dim); font-weight: 700; white-space: nowrap;
   background: var(--glass-bg-strong);
@@ -337,10 +343,13 @@ tbody tr:hover .ds-name::after { content: " ›"; color: var(--accent); font-wei
 .chip {
   background: var(--chip-bg); color: var(--chip-text); font-size: 11px; padding: 3px 9px;
   border-radius: var(--radius-pill); white-space: nowrap; border: 1px solid var(--chip-brd);
-  -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
 }
 .chip.dim { opacity: .85; }
-.chip.more { background: transparent; border-color: transparent; color: var(--text-dim); font-weight: 600; padding-left: 2px; }
+/* '+N' 오버플로 — 다른 칩과 동일한 배경(pill), 색만 muted + 깔끔히 중앙정렬 */
+.chip.more {
+  color: var(--text-dim); font-weight: 600;
+  display: inline-flex; align-items: center; justify-content: center;
+}
 
 /* ---------------- 카드 ---------------- */
 .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(290px, 1fr)); gap: 16px; }
@@ -376,12 +385,14 @@ tbody tr:hover .ds-name::after { content: " ›"; color: var(--accent); font-wei
 .modal { position: fixed; inset: 0; z-index: 60; display: flex; align-items: center; justify-content: center; padding: 24px; }
 .modal-backdrop { position: absolute; inset: 0; background: rgba(8,12,22,.45); -webkit-backdrop-filter: blur(6px); backdrop-filter: blur(6px); }
 .modal-panel {
-  position: relative; border-radius: 24px; max-width: 780px; width: 100%; max-height: 86vh; overflow-y: auto; padding: 24px 26px;
+  position: relative; border-radius: 24px; max-width: 780px; width: 100%; max-height: 86vh; overflow: hidden;
   background: var(--glass-bg-strong);
   -webkit-backdrop-filter: blur(30px) saturate(190%); backdrop-filter: blur(30px) saturate(190%);
   border: 1px solid var(--glass-brd);
   box-shadow: var(--glass-shadow-lg), inset 0 1px 0 var(--glass-rim);
 }
+/* 실제 스크롤은 안쪽에서 — 스크롤바가 둥근 모서리를 뚫고 나오지 않게 */
+.modal-scroll { max-height: 86vh; overflow-y: auto; padding: 24px 26px; }
 .modal-panel h2 { margin: 0 0 2px; font-size: 21px; font-weight: 700; }
 .modal-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; margin-bottom: 16px; }
 .modal-head .meta { font-size: 12px; color: var(--text-dim); }
@@ -450,6 +461,7 @@ tbody tr:hover .ds-name::after { content: " ›"; color: var(--accent); font-wei
 @media (max-width: 920px) {
   .layout { grid-template-columns: 1fr; }
   .sidebar { position: static; max-height: none; }
+  .view-toggle { display: none; }  /* 좁은 화면은 카드 전용 → 표 토글 숨김 */
 }
 @media (max-width: 768px) {
   /* 상단바: 제목 위 / 버튼 줄 아래로 세로 배치 */
@@ -465,7 +477,8 @@ tbody tr:hover .ds-name::after { content: " ›"; color: var(--accent); font-wei
   .toolbar-right { width: 100%; justify-content: space-between; }
   /* 모달: 화면 꽉 차게 + 상세 1열 */
   .modal { padding: 12px; }
-  .modal-panel { padding: 18px 16px; border-radius: 18px; }
+  .modal-panel { border-radius: 18px; }
+  .modal-scroll { padding: 18px 16px; }
   .dl { grid-template-columns: 1fr; gap: 2px 0; }
   .dl dt { padding-top: 10px; font-weight: 600; }
   /* 폼: 1열 */
@@ -5182,7 +5195,7 @@ window.DATASETS = [
   "description": ""
  }
 ];
-window.DATASETS_META = { count: 82, source: "Datasets DB 275b7e86a5bd807d878fdb6f8c8fe382.csv" };
+window.DATASETS_META = { count: 82, source: "Datasets DB.csv" };
 
 </script>
   <script>
@@ -5195,23 +5208,21 @@ window.DATASETS_META = { count: 82, source: "Datasets DB 275b7e86a5bd807d878fdb6
 const DATA = (window.DATASETS || []).map((d, i) => ({ ...d, _id: i }));
 
 /* 사이드바 패싯 (배열형 멀티값 컬럼) — 라벨은 한국어 */
-const FACETS = [
-  { key: "Industry Domain",   label: "산업 분야" },
-  { key: "Task",              label: "태스크" },
-  { key: "Defect Category",   label: "결함 범주" },
-  { key: "Image Modality",    label: "이미지 모달리티" },
-  { key: "Material Domain",   label: "소재" },
-  { key: "Annotation Format", label: "어노테이션 형식" },
-  { key: "Annotation Level",  label: "어노테이션 레벨" },
-  { key: "Process Domain",    label: "공정" },
+/* 사이드바 패싯 — 대표 테이블 컬럼 순서를 앞에 두고, 나머지 필터를 뒤에 */
+const ALL_FACETS = [
+  { key: "Industry Domain",      label: "산업 분야" },
+  { key: "Process Domain",       label: "공정" },
+  { key: "Defect Category",      label: "결함 범주" },
+  { key: "AI based Defect Type", label: "결함 유형" },
+  { key: "Image Modality",       label: "이미지 모달리티" },
+  { key: "License",              label: "라이선스" },
+  { key: "Task",                 label: "태스크" },
+  { key: "Material Domain",      label: "소재" },
+  { key: "Annotation Format",    label: "어노테이션 형식" },
+  { key: "Annotation Level",     label: "어노테이션 레벨" },
+  { key: "Data Source Type",     label: "데이터 생성 방식" },
+  { key: "Dimension",            label: "차원" },
 ];
-/* 단일값 컬럼도 패싯으로 노출 */
-const FACETS_SINGLE = [
-  { key: "Data Source Type", label: "데이터 출처" },
-  { key: "Dimension",        label: "차원" },
-  { key: "License",          label: "라이선스" },
-];
-const ALL_FACETS = [...FACETS, ...FACETS_SINGLE];
 
 const BOOL_FILTERS = [
   { key: "isImage",        label: "이미지" },
@@ -5220,7 +5231,7 @@ const BOOL_FILTERS = [
 ];
 
 const SORTS = [
-  { key: "Total",                       label: "총 이미지 수", num: true },
+  { key: "Total",                       label: "총 데이터 수", num: true },
   { key: "Year",                        label: "연도",         num: true },
   { key: "AI based defect types count", label: "결함 종류 수", num: true },
   { key: "Class",                       label: "클래스 수",    num: true },
@@ -5230,14 +5241,15 @@ const SORTS = [
 
 /* 표 컬럼 */
 const COLUMNS = [
-  { key: "Name",            label: "이름",   type: "name" },
-  { key: "Industry Domain", label: "산업 분야", type: "chips" },
-  { key: "Task",            label: "태스크",  type: "chips" },
-  { key: "Defect Category", label: "결함 범주", type: "chips" },
-  { key: "Image Modality",  label: "모달리티", type: "chips" },
-  { key: "Total",           label: "총 수",  type: "num" },
-  { key: "Year",            label: "연도",   type: "num" },
-  { key: "License",         label: "라이선스", type: "text" },
+  { key: "Name",                 label: "이름",      type: "name",  w: "20%" },
+  { key: "Industry Domain",      label: "산업 분야",  type: "chips", w: "10%" },
+  { key: "Process Domain",       label: "공정",      type: "chips", w: "13%" },
+  { key: "Defect Category",      label: "결함 범주",  type: "chips", w: "10%" },
+  { key: "AI based Defect Type", label: "결함 유형",  type: "chips", w: "15%" },
+  { key: "Image Modality",       label: "모달리티",   type: "chips", w: "7%" },
+  { key: "Total",                label: "총 데이터 수", type: "num",  w: "8%" },
+  { key: "Year",                 label: "연도",      type: "year",  w: "5%" },
+  { key: "License",              label: "라이선스",   type: "text",  w: "12%" },
 ];
 
 /* ---------------- 상태 ---------------- */
@@ -5248,6 +5260,7 @@ const state = {
   sortKey: "Total",
   sortDir: -1,                // -1 내림차순, 1 오름차순
   view: "table",
+  desktopView: "table",       // 데스크톱(넓은 화면)에서 사용자가 선택한 뷰 — 넓어질 때 복원
   showAll: {},                // {facetKey: bool} — 옵션 더보기
 };
 ALL_FACETS.forEach(f => (state.facets[f.key] = new Set()));
@@ -5397,7 +5410,12 @@ function renderTable(rows) {
   const wrap = el("div", "table-wrap");
   const table = el("table");
   const thead = el("thead"); const trh = el("tr");
-  COLUMNS.forEach(c => trh.appendChild(el("th", null, c.label)));
+  COLUMNS.forEach(c => {
+    const th = el("th", null, c.label);
+    if (c.w) th.style.width = c.w;
+    if (c.type === "num" || c.type === "year") th.style.textAlign = "right";  // 숫자 헤더는 값과 같이 우측 정렬
+    trh.appendChild(th);
+  });
   thead.appendChild(trh); table.appendChild(thead);
   const tb = el("tbody");
   rows.forEach(d => {
@@ -5407,6 +5425,7 @@ function renderTable(rows) {
       const td = el("td");
       if (c.type === "name") { td.className = "name"; td.appendChild(el("span", "ds-name", d.Name)); }
       else if (c.type === "num") { td.className = "num"; td.textContent = fmtNum(d[c.key]); }
+      else if (c.type === "year") { td.className = "num"; td.textContent = d[c.key] == null ? "—" : String(d[c.key]); }
       else if (c.type === "chips") td.appendChild(chipList(d[c.key], false, 3));
       else td.textContent = d[c.key] || "—";
       tr.appendChild(td);
@@ -5470,7 +5489,7 @@ function renderStats(rows) {
 /* ---------------- 모달 ---------------- */
 /* 상단 핵심 지표 타일 */
 const STAT_TILES = [
-  { key: "Total",                       label: "총 이미지" },
+  { key: "Total",                       label: "총 데이터" },
   { key: "Abnormal",                    label: "비정상" },
   { key: "Normal",                      label: "정상" },
   { key: "Class",                       label: "클래스 수" },
@@ -5484,9 +5503,9 @@ const DETAIL_GROUPS = [
 ];
 const FIELD_LABELS = {
   "AI based Defect Type": "결함 유형", "AI based defect types count": "결함 종류 수",
-  "Class": "클래스 수", "Total": "총 이미지", "Normal": "정상", "Abnormal": "비정상",
-  "Data Source Type": "데이터 출처", "Defect Category": "결함 범주", "Dimension": "차원",
-  "Image Modality": "모달리티", "Industry Domain": "산업 분야", "Material Domain": "소재",
+  "Class": "클래스 수", "Total": "총 데이터", "Normal": "정상", "Abnormal": "비정상",
+  "Data Source Type": "데이터 생성 방식", "Defect Category": "결함 범주", "Dimension": "차원",
+  "Image Modality": "이미지 모달리티", "Industry Domain": "산업 분야", "Material Domain": "소재",
   "Process Domain": "공정", "Annotation Format": "어노테이션 형식", "Annotation Level": "어노테이션 레벨",
   "Task": "태스크", "Year": "연도", "License": "라이선스", "isImage": "이미지 여부",
   "isDownloadable": "다운로드 가능", "isAutomotive": "자동차 관련", "Automotive process": "자동차 공정",
@@ -5501,6 +5520,7 @@ function fmtVal(v) {
 function openModal(d) {
   const panel = $("#modal-panel");
   panel.innerHTML = "";
+  const scroll = el("div", "modal-scroll");   // 내부 스크롤 영역(둥근 모서리 밖으로 스크롤바 안 나오게)
 
   // 헤더
   const head = el("div", "modal-head");
@@ -5510,9 +5530,9 @@ function openModal(d) {
   head.appendChild(hl);
   const close = el("button", "modal-close", "✕"); close.onclick = closeModal;
   head.appendChild(close);
-  panel.appendChild(head);
+  scroll.appendChild(head);
 
-  if (d.description) panel.appendChild(el("div", "modal-desc", d.description));
+  if (d.description) scroll.appendChild(el("div", "modal-desc", d.description));
 
   // 핵심 지표 타일
   const tiles = el("div", "stat-tiles");
@@ -5522,7 +5542,7 @@ function openModal(d) {
     tile.appendChild(el("div", "st-lbl", t.label));
     tiles.appendChild(tile);
   });
-  panel.appendChild(tiles);
+  scroll.appendChild(tiles);
 
   // 그룹 섹션
   DETAIL_GROUPS.forEach(g => {
@@ -5530,7 +5550,7 @@ function openModal(d) {
     sec.appendChild(el("h4", "ms-title", g.title));
     const dl = el("dl", "dl");
     g.fields.forEach(k => {
-      const val = fmtVal(d[k]);
+      const val = (k === "Year") ? (d[k] == null ? "—" : String(d[k])) : fmtVal(d[k]);  // 연도는 콤마 없이
       dl.appendChild(el("dt", null, FIELD_LABELS[k] || k));
       const dd = el("dd");
       if (Array.isArray(val)) val.forEach(v => dd.appendChild(el("span", "chip", v)));
@@ -5538,14 +5558,15 @@ function openModal(d) {
       dl.appendChild(dd);
     });
     sec.appendChild(dl);
-    panel.appendChild(sec);
+    scroll.appendChild(sec);
   });
 
   if (d.Link) {
     const a = el("a", "modal-link", "원본 데이터셋 열기 ↗");
     a.href = d.Link; a.target = "_blank"; a.rel = "noopener";
-    panel.appendChild(a);
+    scroll.appendChild(a);
   }
+  panel.appendChild(scroll);
   $("#modal").classList.remove("hidden");
 }
 function closeModal() { $("#modal").classList.add("hidden"); }
@@ -5600,6 +5621,7 @@ function slugify(name) {
 function buildAddForm() {
   const panel = $("#add-panel");
   panel.innerHTML = "";
+  const scroll = el("div", "modal-scroll");   // 내부 스크롤(폼이 길어도 끝까지 스크롤 가능)
 
   const head = el("div", "modal-head");
   const hl = el("div");
@@ -5608,9 +5630,9 @@ function buildAddForm() {
   head.appendChild(hl);
   const close = el("button", "modal-close", "✕"); close.onclick = closeAddModal;
   head.appendChild(close);
-  panel.appendChild(head);
+  scroll.appendChild(head);
 
-  panel.appendChild(el("div", "add-note",
+  scroll.appendChild(el("div", "add-note",
     "제출하면 GitHub에 새 파일(PR)로 올라가고, 관리자가 검토·병합한 뒤 재빌드하면 사이트에 반영됩니다. " +
     "여기서의 ‘미리보기 추가’는 이 브라우저 세션에서만 보입니다(저장 아님)."));
 
@@ -5657,7 +5679,7 @@ function buildAddForm() {
     }
     grid.appendChild(field);
   });
-  panel.appendChild(grid);
+  scroll.appendChild(grid);
 
   const actions = el("div", "add-actions");
   const bPrev = el("button", "ghost", "미리보기에 추가"); bPrev.onclick = onPreviewAdd;
@@ -5665,9 +5687,10 @@ function buildAddForm() {
   const bData = el("button", "ghost", "전체 data.js 내려받기"); bData.onclick = onDownloadDataJs;
   const bPR = el("button", "modal-link", "GitHub에 PR로 제출 ↗"); bPR.onclick = onSubmitGitHub; bPR.style.marginTop = "0";
   actions.append(bPrev, bRec, bData, bPR);
-  panel.appendChild(actions);
+  scroll.appendChild(actions);
 
-  panel.appendChild(el("div", "add-status"));
+  scroll.appendChild(el("div", "add-status"));
+  panel.appendChild(scroll);
 }
 
 function collectAddForm() {
@@ -5787,13 +5810,24 @@ function init() {
   let t;
   $("#search").oninput = e => { clearTimeout(t); t = setTimeout(() => { state.q = e.target.value.trim().toLowerCase(); render(); }, 120); };
 
-  // 뷰 토글
+  // 반응형 뷰: 좁은 화면(≤920px)=카드 강제, 넓어지면 데스크톱 선택(기본 표)으로 자동 복귀
+  const narrowMQ = matchMedia("(max-width: 920px)");
+  const syncToggle = () => document.querySelectorAll(".view-toggle button")
+    .forEach(b => b.classList.toggle("active", b.dataset.view === state.view));
+  function applyResponsiveView(doRender) {
+    const want = narrowMQ.matches ? "card" : state.desktopView;
+    if (state.view !== want) { state.view = want; syncToggle(); if (doRender) render(); }
+  }
+  // 뷰 토글 (좁은 화면에선 숨겨져 데스크톱에서만 클릭됨 → 그 선택을 기억)
   document.querySelectorAll(".view-toggle button").forEach(btn => {
     btn.onclick = () => {
-      document.querySelectorAll(".view-toggle button").forEach(b => b.classList.remove("active"));
-      btn.classList.add("active"); state.view = btn.dataset.view; render();
+      state.view = btn.dataset.view;
+      if (!narrowMQ.matches) state.desktopView = state.view;
+      syncToggle(); render();
     };
   });
+  narrowMQ.addEventListener("change", () => applyResponsiveView(true));
+  applyResponsiveView(false);  // 초기 상태 세팅(아래 최초 render가 반영)
 
   // 초기화
   $("#btn-reset").onclick = () => {

--- a/web/app.js
+++ b/web/app.js
@@ -7,23 +7,21 @@
 const DATA = (window.DATASETS || []).map((d, i) => ({ ...d, _id: i }));
 
 /* 사이드바 패싯 (배열형 멀티값 컬럼) — 라벨은 한국어 */
-const FACETS = [
-  { key: "Industry Domain",   label: "산업 분야" },
-  { key: "Task",              label: "태스크" },
-  { key: "Defect Category",   label: "결함 범주" },
-  { key: "Image Modality",    label: "이미지 모달리티" },
-  { key: "Material Domain",   label: "소재" },
-  { key: "Annotation Format", label: "어노테이션 형식" },
-  { key: "Annotation Level",  label: "어노테이션 레벨" },
-  { key: "Process Domain",    label: "공정" },
+/* 사이드바 패싯 — 대표 테이블 컬럼 순서를 앞에 두고, 나머지 필터를 뒤에 */
+const ALL_FACETS = [
+  { key: "Industry Domain",      label: "산업 분야" },
+  { key: "Process Domain",       label: "공정" },
+  { key: "Defect Category",      label: "결함 범주" },
+  { key: "AI based Defect Type", label: "결함 유형" },
+  { key: "Image Modality",       label: "이미지 모달리티" },
+  { key: "License",              label: "라이선스" },
+  { key: "Task",                 label: "태스크" },
+  { key: "Material Domain",      label: "소재" },
+  { key: "Annotation Format",    label: "어노테이션 형식" },
+  { key: "Annotation Level",     label: "어노테이션 레벨" },
+  { key: "Data Source Type",     label: "데이터 생성 방식" },
+  { key: "Dimension",            label: "차원" },
 ];
-/* 단일값 컬럼도 패싯으로 노출 */
-const FACETS_SINGLE = [
-  { key: "Data Source Type", label: "데이터 출처" },
-  { key: "Dimension",        label: "차원" },
-  { key: "License",          label: "라이선스" },
-];
-const ALL_FACETS = [...FACETS, ...FACETS_SINGLE];
 
 const BOOL_FILTERS = [
   { key: "isImage",        label: "이미지" },
@@ -32,7 +30,7 @@ const BOOL_FILTERS = [
 ];
 
 const SORTS = [
-  { key: "Total",                       label: "총 이미지 수", num: true },
+  { key: "Total",                       label: "총 데이터 수", num: true },
   { key: "Year",                        label: "연도",         num: true },
   { key: "AI based defect types count", label: "결함 종류 수", num: true },
   { key: "Class",                       label: "클래스 수",    num: true },
@@ -42,14 +40,15 @@ const SORTS = [
 
 /* 표 컬럼 */
 const COLUMNS = [
-  { key: "Name",            label: "이름",   type: "name" },
-  { key: "Industry Domain", label: "산업 분야", type: "chips" },
-  { key: "Task",            label: "태스크",  type: "chips" },
-  { key: "Defect Category", label: "결함 범주", type: "chips" },
-  { key: "Image Modality",  label: "모달리티", type: "chips" },
-  { key: "Total",           label: "총 수",  type: "num" },
-  { key: "Year",            label: "연도",   type: "num" },
-  { key: "License",         label: "라이선스", type: "text" },
+  { key: "Name",                 label: "이름",      type: "name",  w: "20%" },
+  { key: "Industry Domain",      label: "산업 분야",  type: "chips", w: "10%" },
+  { key: "Process Domain",       label: "공정",      type: "chips", w: "13%" },
+  { key: "Defect Category",      label: "결함 범주",  type: "chips", w: "10%" },
+  { key: "AI based Defect Type", label: "결함 유형",  type: "chips", w: "15%" },
+  { key: "Image Modality",       label: "모달리티",   type: "chips", w: "7%" },
+  { key: "Total",                label: "총 데이터 수", type: "num",  w: "8%" },
+  { key: "Year",                 label: "연도",      type: "year",  w: "5%" },
+  { key: "License",              label: "라이선스",   type: "text",  w: "12%" },
 ];
 
 /* ---------------- 상태 ---------------- */
@@ -60,6 +59,7 @@ const state = {
   sortKey: "Total",
   sortDir: -1,                // -1 내림차순, 1 오름차순
   view: "table",
+  desktopView: "table",       // 데스크톱(넓은 화면)에서 사용자가 선택한 뷰 — 넓어질 때 복원
   showAll: {},                // {facetKey: bool} — 옵션 더보기
 };
 ALL_FACETS.forEach(f => (state.facets[f.key] = new Set()));
@@ -209,7 +209,12 @@ function renderTable(rows) {
   const wrap = el("div", "table-wrap");
   const table = el("table");
   const thead = el("thead"); const trh = el("tr");
-  COLUMNS.forEach(c => trh.appendChild(el("th", null, c.label)));
+  COLUMNS.forEach(c => {
+    const th = el("th", null, c.label);
+    if (c.w) th.style.width = c.w;
+    if (c.type === "num" || c.type === "year") th.style.textAlign = "right";  // 숫자 헤더는 값과 같이 우측 정렬
+    trh.appendChild(th);
+  });
   thead.appendChild(trh); table.appendChild(thead);
   const tb = el("tbody");
   rows.forEach(d => {
@@ -219,6 +224,7 @@ function renderTable(rows) {
       const td = el("td");
       if (c.type === "name") { td.className = "name"; td.appendChild(el("span", "ds-name", d.Name)); }
       else if (c.type === "num") { td.className = "num"; td.textContent = fmtNum(d[c.key]); }
+      else if (c.type === "year") { td.className = "num"; td.textContent = d[c.key] == null ? "—" : String(d[c.key]); }
       else if (c.type === "chips") td.appendChild(chipList(d[c.key], false, 3));
       else td.textContent = d[c.key] || "—";
       tr.appendChild(td);
@@ -282,7 +288,7 @@ function renderStats(rows) {
 /* ---------------- 모달 ---------------- */
 /* 상단 핵심 지표 타일 */
 const STAT_TILES = [
-  { key: "Total",                       label: "총 이미지" },
+  { key: "Total",                       label: "총 데이터" },
   { key: "Abnormal",                    label: "비정상" },
   { key: "Normal",                      label: "정상" },
   { key: "Class",                       label: "클래스 수" },
@@ -296,9 +302,9 @@ const DETAIL_GROUPS = [
 ];
 const FIELD_LABELS = {
   "AI based Defect Type": "결함 유형", "AI based defect types count": "결함 종류 수",
-  "Class": "클래스 수", "Total": "총 이미지", "Normal": "정상", "Abnormal": "비정상",
-  "Data Source Type": "데이터 출처", "Defect Category": "결함 범주", "Dimension": "차원",
-  "Image Modality": "모달리티", "Industry Domain": "산업 분야", "Material Domain": "소재",
+  "Class": "클래스 수", "Total": "총 데이터", "Normal": "정상", "Abnormal": "비정상",
+  "Data Source Type": "데이터 생성 방식", "Defect Category": "결함 범주", "Dimension": "차원",
+  "Image Modality": "이미지 모달리티", "Industry Domain": "산업 분야", "Material Domain": "소재",
   "Process Domain": "공정", "Annotation Format": "어노테이션 형식", "Annotation Level": "어노테이션 레벨",
   "Task": "태스크", "Year": "연도", "License": "라이선스", "isImage": "이미지 여부",
   "isDownloadable": "다운로드 가능", "isAutomotive": "자동차 관련", "Automotive process": "자동차 공정",
@@ -313,6 +319,7 @@ function fmtVal(v) {
 function openModal(d) {
   const panel = $("#modal-panel");
   panel.innerHTML = "";
+  const scroll = el("div", "modal-scroll");   // 내부 스크롤 영역(둥근 모서리 밖으로 스크롤바 안 나오게)
 
   // 헤더
   const head = el("div", "modal-head");
@@ -322,9 +329,9 @@ function openModal(d) {
   head.appendChild(hl);
   const close = el("button", "modal-close", "✕"); close.onclick = closeModal;
   head.appendChild(close);
-  panel.appendChild(head);
+  scroll.appendChild(head);
 
-  if (d.description) panel.appendChild(el("div", "modal-desc", d.description));
+  if (d.description) scroll.appendChild(el("div", "modal-desc", d.description));
 
   // 핵심 지표 타일
   const tiles = el("div", "stat-tiles");
@@ -334,7 +341,7 @@ function openModal(d) {
     tile.appendChild(el("div", "st-lbl", t.label));
     tiles.appendChild(tile);
   });
-  panel.appendChild(tiles);
+  scroll.appendChild(tiles);
 
   // 그룹 섹션
   DETAIL_GROUPS.forEach(g => {
@@ -342,7 +349,7 @@ function openModal(d) {
     sec.appendChild(el("h4", "ms-title", g.title));
     const dl = el("dl", "dl");
     g.fields.forEach(k => {
-      const val = fmtVal(d[k]);
+      const val = (k === "Year") ? (d[k] == null ? "—" : String(d[k])) : fmtVal(d[k]);  // 연도는 콤마 없이
       dl.appendChild(el("dt", null, FIELD_LABELS[k] || k));
       const dd = el("dd");
       if (Array.isArray(val)) val.forEach(v => dd.appendChild(el("span", "chip", v)));
@@ -350,14 +357,15 @@ function openModal(d) {
       dl.appendChild(dd);
     });
     sec.appendChild(dl);
-    panel.appendChild(sec);
+    scroll.appendChild(sec);
   });
 
   if (d.Link) {
     const a = el("a", "modal-link", "원본 데이터셋 열기 ↗");
     a.href = d.Link; a.target = "_blank"; a.rel = "noopener";
-    panel.appendChild(a);
+    scroll.appendChild(a);
   }
+  panel.appendChild(scroll);
   $("#modal").classList.remove("hidden");
 }
 function closeModal() { $("#modal").classList.add("hidden"); }
@@ -412,6 +420,7 @@ function slugify(name) {
 function buildAddForm() {
   const panel = $("#add-panel");
   panel.innerHTML = "";
+  const scroll = el("div", "modal-scroll");   // 내부 스크롤(폼이 길어도 끝까지 스크롤 가능)
 
   const head = el("div", "modal-head");
   const hl = el("div");
@@ -420,9 +429,9 @@ function buildAddForm() {
   head.appendChild(hl);
   const close = el("button", "modal-close", "✕"); close.onclick = closeAddModal;
   head.appendChild(close);
-  panel.appendChild(head);
+  scroll.appendChild(head);
 
-  panel.appendChild(el("div", "add-note",
+  scroll.appendChild(el("div", "add-note",
     "제출하면 GitHub에 새 파일(PR)로 올라가고, 관리자가 검토·병합한 뒤 재빌드하면 사이트에 반영됩니다. " +
     "여기서의 ‘미리보기 추가’는 이 브라우저 세션에서만 보입니다(저장 아님)."));
 
@@ -469,7 +478,7 @@ function buildAddForm() {
     }
     grid.appendChild(field);
   });
-  panel.appendChild(grid);
+  scroll.appendChild(grid);
 
   const actions = el("div", "add-actions");
   const bPrev = el("button", "ghost", "미리보기에 추가"); bPrev.onclick = onPreviewAdd;
@@ -477,9 +486,10 @@ function buildAddForm() {
   const bData = el("button", "ghost", "전체 data.js 내려받기"); bData.onclick = onDownloadDataJs;
   const bPR = el("button", "modal-link", "GitHub에 PR로 제출 ↗"); bPR.onclick = onSubmitGitHub; bPR.style.marginTop = "0";
   actions.append(bPrev, bRec, bData, bPR);
-  panel.appendChild(actions);
+  scroll.appendChild(actions);
 
-  panel.appendChild(el("div", "add-status"));
+  scroll.appendChild(el("div", "add-status"));
+  panel.appendChild(scroll);
 }
 
 function collectAddForm() {
@@ -599,13 +609,24 @@ function init() {
   let t;
   $("#search").oninput = e => { clearTimeout(t); t = setTimeout(() => { state.q = e.target.value.trim().toLowerCase(); render(); }, 120); };
 
-  // 뷰 토글
+  // 반응형 뷰: 좁은 화면(≤920px)=카드 강제, 넓어지면 데스크톱 선택(기본 표)으로 자동 복귀
+  const narrowMQ = matchMedia("(max-width: 920px)");
+  const syncToggle = () => document.querySelectorAll(".view-toggle button")
+    .forEach(b => b.classList.toggle("active", b.dataset.view === state.view));
+  function applyResponsiveView(doRender) {
+    const want = narrowMQ.matches ? "card" : state.desktopView;
+    if (state.view !== want) { state.view = want; syncToggle(); if (doRender) render(); }
+  }
+  // 뷰 토글 (좁은 화면에선 숨겨져 데스크톱에서만 클릭됨 → 그 선택을 기억)
   document.querySelectorAll(".view-toggle button").forEach(btn => {
     btn.onclick = () => {
-      document.querySelectorAll(".view-toggle button").forEach(b => b.classList.remove("active"));
-      btn.classList.add("active"); state.view = btn.dataset.view; render();
+      state.view = btn.dataset.view;
+      if (!narrowMQ.matches) state.desktopView = state.view;
+      syncToggle(); render();
     };
   });
+  narrowMQ.addEventListener("change", () => applyResponsiveView(true));
+  applyResponsiveView(false);  // 초기 상태 세팅(아래 최초 render가 반영)
 
   // 초기화
   $("#btn-reset").onclick = () => {

--- a/web/styles.css
+++ b/web/styles.css
@@ -79,6 +79,14 @@ a:hover { text-decoration: underline; }
 .hidden { display: none !important; }
 .svg-defs { position: absolute; width: 0; height: 0; pointer-events: none; }
 
+/* ---------------- 스크롤바 (테마에 맞춘 차분한 스타일) ---------------- */
+* { scrollbar-width: thin; scrollbar-color: color-mix(in srgb, var(--text-dim) 45%, transparent) transparent; }
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: color-mix(in srgb, var(--text-dim) 38%, transparent); border-radius: 8px; border: 2px solid transparent; background-clip: padding-box; }
+::-webkit-scrollbar-thumb:hover { background: color-mix(in srgb, var(--text-dim) 65%, transparent); }
+::-webkit-scrollbar-corner { background: transparent; }
+
 /* ---------------- 오로라 배경 ---------------- */
 .bg-aurora {
   position: fixed; inset: 0; z-index: -2; overflow: hidden;
@@ -118,12 +126,10 @@ a:hover { text-decoration: underline; }
   border: 1px solid var(--glass-brd);
   box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-rim), inset 0 0 0 1px rgba(255,255,255,.04);
 }
-/* Chromium 한정 굴절 향상 */
+/* Chromium 한정 굴절 향상 — 큰 스크롤 영역(표/카드)은 성능 위해 제외 */
 .refraction .topbar,
 .refraction .sidebar,
 .refraction .stats,
-.refraction .table-wrap,
-.refraction .card,
 .refraction .modal-panel {
   backdrop-filter: blur(var(--blur)) saturate(var(--sat)) url(#glass-refraction);
 }
@@ -302,7 +308,7 @@ a:hover { text-decoration: underline; }
   border: 1px solid var(--glass-brd);
   box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-rim);
 }
-table { border-collapse: collapse; width: 100%; font-size: 13px; }
+table { border-collapse: collapse; width: 100%; font-size: 13px; table-layout: fixed; min-width: 880px; }
 thead th {
   text-align: left; padding: 12px 14px; color: var(--text-dim); font-weight: 700; white-space: nowrap;
   background: var(--glass-bg-strong);
@@ -329,10 +335,13 @@ tbody tr:hover .ds-name::after { content: " ›"; color: var(--accent); font-wei
 .chip {
   background: var(--chip-bg); color: var(--chip-text); font-size: 11px; padding: 3px 9px;
   border-radius: var(--radius-pill); white-space: nowrap; border: 1px solid var(--chip-brd);
-  -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
 }
 .chip.dim { opacity: .85; }
-.chip.more { background: transparent; border-color: transparent; color: var(--text-dim); font-weight: 600; padding-left: 2px; }
+/* '+N' 오버플로 — 다른 칩과 동일한 배경(pill), 색만 muted + 깔끔히 중앙정렬 */
+.chip.more {
+  color: var(--text-dim); font-weight: 600;
+  display: inline-flex; align-items: center; justify-content: center;
+}
 
 /* ---------------- 카드 ---------------- */
 .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(290px, 1fr)); gap: 16px; }
@@ -368,12 +377,14 @@ tbody tr:hover .ds-name::after { content: " ›"; color: var(--accent); font-wei
 .modal { position: fixed; inset: 0; z-index: 60; display: flex; align-items: center; justify-content: center; padding: 24px; }
 .modal-backdrop { position: absolute; inset: 0; background: rgba(8,12,22,.45); -webkit-backdrop-filter: blur(6px); backdrop-filter: blur(6px); }
 .modal-panel {
-  position: relative; border-radius: 24px; max-width: 780px; width: 100%; max-height: 86vh; overflow-y: auto; padding: 24px 26px;
+  position: relative; border-radius: 24px; max-width: 780px; width: 100%; max-height: 86vh; overflow: hidden;
   background: var(--glass-bg-strong);
   -webkit-backdrop-filter: blur(30px) saturate(190%); backdrop-filter: blur(30px) saturate(190%);
   border: 1px solid var(--glass-brd);
   box-shadow: var(--glass-shadow-lg), inset 0 1px 0 var(--glass-rim);
 }
+/* 실제 스크롤은 안쪽에서 — 스크롤바가 둥근 모서리를 뚫고 나오지 않게 */
+.modal-scroll { max-height: 86vh; overflow-y: auto; padding: 24px 26px; }
 .modal-panel h2 { margin: 0 0 2px; font-size: 21px; font-weight: 700; }
 .modal-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; margin-bottom: 16px; }
 .modal-head .meta { font-size: 12px; color: var(--text-dim); }
@@ -442,6 +453,7 @@ tbody tr:hover .ds-name::after { content: " ›"; color: var(--accent); font-wei
 @media (max-width: 920px) {
   .layout { grid-template-columns: 1fr; }
   .sidebar { position: static; max-height: none; }
+  .view-toggle { display: none; }  /* 좁은 화면은 카드 전용 → 표 토글 숨김 */
 }
 @media (max-width: 768px) {
   /* 상단바: 제목 위 / 버튼 줄 아래로 세로 배치 */
@@ -457,7 +469,8 @@ tbody tr:hover .ds-name::after { content: " ›"; color: var(--accent); font-wei
   .toolbar-right { width: 100%; justify-content: space-between; }
   /* 모달: 화면 꽉 차게 + 상세 1열 */
   .modal { padding: 12px; }
-  .modal-panel { padding: 18px 16px; border-radius: 18px; }
+  .modal-panel { border-radius: 18px; }
+  .modal-scroll { padding: 18px 16px; }
   .dl { grid-template-columns: 1fr; gap: 2px 0; }
   .dl dt { padding-top: 10px; font-weight: 600; }
   /* 폼: 1열 */


### PR DESCRIPTION
디자인 2차 라운드 (로컬 preview.html로 검토 후 확정).

- **컬럼**: 태스크 제거 / 공정·결함유형 추가·재정렬, 고정 레이아웃+비율폭, 이름 폭 확대, 숫자 헤더 우측정렬, 전체 폭 균일
- **사이드바**: 컬럼 순서 맞춰 필터 재정렬 + 결함유형 필터 추가
- **용어**: 총 데이터 / 데이터 생성 방식 / 이미지 모달리티
- **모달·추가폼**: 내부 스크롤 영역(스크롤바 모서리 정리), 연도 콤마 제거, +N 칩 정리
- **성능**: 스크롤바 테마화, 칩 blur·표/카드 굴절 제거 → 스크롤 부드럽게
- **반응형**: ≤920px 카드 자동전환(표 토글 숨김) ↔ 넓어지면 표 복원(데스크톱 선택 기억)

머지 시 Pages 자동 재배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)