### PR TITLE
fix: 상세 링크 파싱·용어 통일·버튼 정리

### DIFF
--- a/standalone.html
+++ b/standalone.html
@@ -417,8 +417,11 @@ tbody tr:hover .ds-name::after { content: " ›"; color: var(--accent); font-wei
 .dl dt { color: var(--text-dim); font-size: 12.5px; padding-top: 2px; }
 .dl dd { margin: 0; font-size: 13.5px; display: flex; flex-wrap: wrap; gap: 5px; align-items: center; }
 .modal-desc { margin: 16px 0 4px; padding: 14px; background: var(--control-bg); border: 1px solid var(--glass-brd); border-radius: var(--radius-sm); font-size: 13px; color: var(--text-dim); }
+.modal-links { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 18px; }
+.modal-links .modal-link { margin-top: 0; }
 .modal-link {
   display: inline-block; margin-top: 18px; color: #fff; padding: 10px 18px; border-radius: var(--radius-sm); font-size: 13px; font-weight: 600;
+  border: none; -webkit-appearance: none; appearance: none; cursor: pointer;  /* <button>의 기본 테두리/네이티브 스타일 제거 → <a> 버튼과 동일하게 */
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
   box-shadow: 0 6px 18px rgba(59,108,255,.4), inset 0 1px 0 rgba(255,255,255,.4);
 }
@@ -5517,6 +5520,24 @@ function fmtVal(v) {
   if (typeof v === "number") return v.toLocaleString("en-US");
   return v || "—";
 }
+/* Link 필드에서 URL을 모두 추출 + 앞 라벨로 종류 판별 (한 셀에 데이터셋/논문 등 여러 링크 대응) */
+/* 용어 통일: 논문 계열 → "논문 URL", 그 외(다운로드·원본·repo 등) → "데이터셋 URL" */
+function linkLabel(ctx) {
+  const t = (ctx || "").toLowerCase();
+  if (/(paper|논문|arxiv|ieee|doi|stamp|article)/.test(t)) return "논문 URL";
+  return "데이터셋 URL";
+}
+function parseLinks(raw) {
+  raw = (raw || "").trim();
+  if (!raw) return [];
+  const re = /https?:\/\/[^\s,]+/g;
+  const found = []; let m, last = 0;
+  while ((m = re.exec(raw))) {
+    found.push({ url: m[0].replace(/[).,;]+$/, ""), ctx: raw.slice(last, m.index) });
+    last = re.lastIndex;
+  }
+  return found.map(o => ({ url: o.url, label: linkLabel(o.ctx) }));
+}
 function openModal(d) {
   const panel = $("#modal-panel");
   panel.innerHTML = "";
@@ -5561,10 +5582,15 @@ function openModal(d) {
     scroll.appendChild(sec);
   });
 
-  if (d.Link) {
-    const a = el("a", "modal-link", "원본 데이터셋 열기 ↗");
-    a.href = d.Link; a.target = "_blank"; a.rel = "noopener";
-    scroll.appendChild(a);
+  const links = parseLinks(d.Link);
+  if (links.length) {
+    const lw = el("div", "modal-links");
+    links.forEach(l => {
+      const a = el("a", "modal-link", l.label + " ↗");
+      a.href = l.url; a.target = "_blank"; a.rel = "noopener";
+      lw.appendChild(a);
+    });
+    scroll.appendChild(lw);
   }
   panel.appendChild(scroll);
   $("#modal").classList.remove("hidden");

--- a/web/app.js
+++ b/web/app.js
@@ -316,6 +316,24 @@ function fmtVal(v) {
   if (typeof v === "number") return v.toLocaleString("en-US");
   return v || "—";
 }
+/* Link 필드에서 URL을 모두 추출 + 앞 라벨로 종류 판별 (한 셀에 데이터셋/논문 등 여러 링크 대응) */
+/* 용어 통일: 논문 계열 → "논문 URL", 그 외(다운로드·원본·repo 등) → "데이터셋 URL" */
+function linkLabel(ctx) {
+  const t = (ctx || "").toLowerCase();
+  if (/(paper|논문|arxiv|ieee|doi|stamp|article)/.test(t)) return "논문 URL";
+  return "데이터셋 URL";
+}
+function parseLinks(raw) {
+  raw = (raw || "").trim();
+  if (!raw) return [];
+  const re = /https?:\/\/[^\s,]+/g;
+  const found = []; let m, last = 0;
+  while ((m = re.exec(raw))) {
+    found.push({ url: m[0].replace(/[).,;]+$/, ""), ctx: raw.slice(last, m.index) });
+    last = re.lastIndex;
+  }
+  return found.map(o => ({ url: o.url, label: linkLabel(o.ctx) }));
+}
 function openModal(d) {
   const panel = $("#modal-panel");
   panel.innerHTML = "";
@@ -360,10 +378,15 @@ function openModal(d) {
     scroll.appendChild(sec);
   });
 
-  if (d.Link) {
-    const a = el("a", "modal-link", "원본 데이터셋 열기 ↗");
-    a.href = d.Link; a.target = "_blank"; a.rel = "noopener";
-    scroll.appendChild(a);
+  const links = parseLinks(d.Link);
+  if (links.length) {
+    const lw = el("div", "modal-links");
+    links.forEach(l => {
+      const a = el("a", "modal-link", l.label + " ↗");
+      a.href = l.url; a.target = "_blank"; a.rel = "noopener";
+      lw.appendChild(a);
+    });
+    scroll.appendChild(lw);
   }
   panel.appendChild(scroll);
   $("#modal").classList.remove("hidden");

--- a/web/styles.css
+++ b/web/styles.css
@@ -409,8 +409,11 @@ tbody tr:hover .ds-name::after { content: " ›"; color: var(--accent); font-wei
 .dl dt { color: var(--text-dim); font-size: 12.5px; padding-top: 2px; }
 .dl dd { margin: 0; font-size: 13.5px; display: flex; flex-wrap: wrap; gap: 5px; align-items: center; }
 .modal-desc { margin: 16px 0 4px; padding: 14px; background: var(--control-bg); border: 1px solid var(--glass-brd); border-radius: var(--radius-sm); font-size: 13px; color: var(--text-dim); }
+.modal-links { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 18px; }
+.modal-links .modal-link { margin-top: 0; }
 .modal-link {
   display: inline-block; margin-top: 18px; color: #fff; padding: 10px 18px; border-radius: var(--radius-sm); font-size: 13px; font-weight: 600;
+  border: none; -webkit-appearance: none; appearance: none; cursor: pointer;  /* <button>의 기본 테두리/네이티브 스타일 제거 → <a> 버튼과 동일하게 */
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
   box-shadow: 0 6px 18px rgba(59,108,255,.4), inset 0 1px 0 rgba(255,255,255,.4);
 }


### PR DESCRIPTION
- 한 Link 셀의 여러 URL(Download/Paper 등)을 **URL별 버튼으로 분리** → OSPD처럼 깨지던 링크 해결
- 링크 버튼 용어 통일: **데이터셋 URL / 논문 URL**
- GitHub PR 버튼 `<button>` 기본 테두리 제거 → 데이터셋 URL 버튼과 동일 스타일

머지 시 Pages 자동 재배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)