### PR TITLE
feat: 표 가로 드래그 스크롤 + 칩 한 줄 유지(좁은 화면 가독성)

### DIFF
--- a/standalone.html
+++ b/standalone.html
@@ -310,13 +310,16 @@ a:hover { text-decoration: underline; }
 /* ---------------- 표 ---------------- */
 .table-wrap {
   overflow-x: auto; border-radius: var(--radius);
+  cursor: grab;   /* 좌우 드래그로 가로 스크롤 */
   background: var(--glass-bg);
   -webkit-backdrop-filter: blur(var(--blur)) saturate(var(--sat));
   backdrop-filter: blur(var(--blur)) saturate(var(--sat));
   border: 1px solid var(--glass-brd);
   box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-rim);
 }
-table { border-collapse: collapse; width: 100%; font-size: 13px; table-layout: fixed; min-width: 880px; }
+.table-wrap.dragging { cursor: grabbing; user-select: none; }
+/* 칸이 쪼그라들어 칩 글자가 줄바꿈되지 않도록 충분한 최소 폭 — 좁으면 .table-wrap이 가로 스크롤 */
+table { border-collapse: collapse; width: 100%; font-size: 13px; table-layout: fixed; min-width: 1500px; }
 thead th {
   text-align: left; padding: 12px 14px; color: var(--text-dim); font-weight: 700; white-space: nowrap;
   background: var(--glass-bg-strong);
@@ -337,10 +340,8 @@ td.name { max-width: 230px; }
 tbody tr:hover .ds-name { color: var(--accent); }
 tbody tr:hover .ds-name::after { content: " ›"; color: var(--accent); font-weight: 700; }
 
-/* 칩 컨테이너는 칸 너비를 넘지 않게(고정 레이아웃에서 옆 칸 침범 방지) */
+/* 칩 컨테이너는 칸 너비를 넘지 않게(여러 칩은 칸 안에서 줄바꿈, 칩 글자 자체는 한 줄 유지) */
 .cell-chips { display: flex; flex-wrap: wrap; gap: 4px; max-width: 100%; min-width: 0; }
-/* 긴 칩('Structural Anomaly' 등)은 칸 안에서 줄바꿈 — 옆 칸으로 넘치지 않도록 */
-.cell-chips .chip { white-space: normal; }
 
 /* ---------------- 칩 ---------------- */
 .chip {
@@ -5433,7 +5434,34 @@ function renderTable(rows) {
     tb.appendChild(tr);
   });
   table.appendChild(tb); wrap.appendChild(table);
+  enableDragScroll(wrap);
   return wrap;
+}
+
+/* 표를 마우스 좌우 드래그로 가로 스크롤 — 좁은 화면에서 칸 쪼그라듦 없이 밀어서 보기 */
+function enableDragScroll(wrap) {
+  let down = false, startX = 0, startLeft = 0, moved = false;
+  wrap.addEventListener("pointerdown", e => {
+    if (e.pointerType !== "mouse" || e.button !== 0) return;  // 마우스 좌클릭만(터치패드/터치는 native 스크롤)
+    down = true; moved = false; startX = e.clientX; startLeft = wrap.scrollLeft;
+    wrap.classList.add("dragging");
+    try { wrap.setPointerCapture(e.pointerId); } catch (_) {}
+  });
+  wrap.addEventListener("pointermove", e => {
+    if (!down) return;
+    const dx = e.clientX - startX;
+    if (Math.abs(dx) > 4) moved = true;          // 4px 넘게 움직이면 '드래그'로 간주
+    wrap.scrollLeft = startLeft - dx;
+  });
+  const end = e => {
+    if (!down) return;
+    down = false; wrap.classList.remove("dragging");
+    try { wrap.releasePointerCapture(e.pointerId); } catch (_) {}
+  };
+  wrap.addEventListener("pointerup", end);
+  wrap.addEventListener("pointercancel", end);
+  // 드래그였으면 뒤따르는 click을 막아 행 상세 모달이 열리지 않게(캡처 단계에서 차단)
+  wrap.addEventListener("click", e => { if (moved) { e.stopPropagation(); moved = false; } }, true);
 }
 
 function renderCards(rows) {

--- a/web/app.js
+++ b/web/app.js
@@ -232,7 +232,34 @@ function renderTable(rows) {
     tb.appendChild(tr);
   });
   table.appendChild(tb); wrap.appendChild(table);
+  enableDragScroll(wrap);
   return wrap;
+}
+
+/* 표를 마우스 좌우 드래그로 가로 스크롤 — 좁은 화면에서 칸 쪼그라듦 없이 밀어서 보기 */
+function enableDragScroll(wrap) {
+  let down = false, startX = 0, startLeft = 0, moved = false;
+  wrap.addEventListener("pointerdown", e => {
+    if (e.pointerType !== "mouse" || e.button !== 0) return;  // 마우스 좌클릭만(터치패드/터치는 native 스크롤)
+    down = true; moved = false; startX = e.clientX; startLeft = wrap.scrollLeft;
+    wrap.classList.add("dragging");
+    try { wrap.setPointerCapture(e.pointerId); } catch (_) {}
+  });
+  wrap.addEventListener("pointermove", e => {
+    if (!down) return;
+    const dx = e.clientX - startX;
+    if (Math.abs(dx) > 4) moved = true;          // 4px 넘게 움직이면 '드래그'로 간주
+    wrap.scrollLeft = startLeft - dx;
+  });
+  const end = e => {
+    if (!down) return;
+    down = false; wrap.classList.remove("dragging");
+    try { wrap.releasePointerCapture(e.pointerId); } catch (_) {}
+  };
+  wrap.addEventListener("pointerup", end);
+  wrap.addEventListener("pointercancel", end);
+  // 드래그였으면 뒤따르는 click을 막아 행 상세 모달이 열리지 않게(캡처 단계에서 차단)
+  wrap.addEventListener("click", e => { if (moved) { e.stopPropagation(); moved = false; } }, true);
 }
 
 function renderCards(rows) {

--- a/web/styles.css
+++ b/web/styles.css
@@ -302,13 +302,16 @@ a:hover { text-decoration: underline; }
 /* ---------------- 표 ---------------- */
 .table-wrap {
   overflow-x: auto; border-radius: var(--radius);
+  cursor: grab;   /* 좌우 드래그로 가로 스크롤 */
   background: var(--glass-bg);
   -webkit-backdrop-filter: blur(var(--blur)) saturate(var(--sat));
   backdrop-filter: blur(var(--blur)) saturate(var(--sat));
   border: 1px solid var(--glass-brd);
   box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-rim);
 }
-table { border-collapse: collapse; width: 100%; font-size: 13px; table-layout: fixed; min-width: 880px; }
+.table-wrap.dragging { cursor: grabbing; user-select: none; }
+/* 칸이 쪼그라들어 칩 글자가 줄바꿈되지 않도록 충분한 최소 폭 — 좁으면 .table-wrap이 가로 스크롤 */
+table { border-collapse: collapse; width: 100%; font-size: 13px; table-layout: fixed; min-width: 1500px; }
 thead th {
   text-align: left; padding: 12px 14px; color: var(--text-dim); font-weight: 700; white-space: nowrap;
   background: var(--glass-bg-strong);
@@ -329,10 +332,8 @@ td.name { max-width: 230px; }
 tbody tr:hover .ds-name { color: var(--accent); }
 tbody tr:hover .ds-name::after { content: " ›"; color: var(--accent); font-weight: 700; }
 
-/* 칩 컨테이너는 칸 너비를 넘지 않게(고정 레이아웃에서 옆 칸 침범 방지) */
+/* 칩 컨테이너는 칸 너비를 넘지 않게(여러 칩은 칸 안에서 줄바꿈, 칩 글자 자체는 한 줄 유지) */
 .cell-chips { display: flex; flex-wrap: wrap; gap: 4px; max-width: 100%; min-width: 0; }
-/* 긴 칩('Structural Anomaly' 등)은 칸 안에서 줄바꿈 — 옆 칸으로 넘치지 않도록 */
-.cell-chips .chip { white-space: normal; }
 
 /* ---------------- 칩 ---------------- */
 .chip {


### PR DESCRIPTION
## 표 좁은 화면 가독성: 가로 드래그 스크롤 + 칩 한 줄 유지

**문제:** 창을 좁히면 표 칸이 쪼그라들며 칩 글자가 줄바꿈("Process Monitoring"→2줄, "Structural Anomaly"→2줄)돼 지저분하게 보임.

**해결:**
- `.cell-chips .chip { white-space: normal }` 제거 → 칩 글자 항상 한 줄(깔끔한 알약)
- 표 `min-width 880 → 1500px` → 칸이 줄지 않아 넓은 레이아웃 유지, 좁으면 `.table-wrap` 가로 스크롤
- **마우스 좌우 드래그로 가로 스크롤**(`enableDragScroll`): `cursor: grab`, 4px 임계로 드래그/클릭 구분(드래그 시 행 상세 모달 안 열림), 터치·트랙패드는 native 스크롤 유지

**검증:** 헤드리스 렌더(1300px·1900px) — 좁은 화면도 칩 전부 한 줄, 가로 스크롤로 전 컬럼 접근 / 넓은 화면은 전체 표시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
